### PR TITLE
Fixes for Makefile use, GCC

### DIFF
--- a/CppUnitLite/Makefile
+++ b/CppUnitLite/Makefile
@@ -12,5 +12,5 @@ libCppUnitLite.a: $(OBJ)
 all: libCppUnitLite.a
 
 clean:
-	rm *.a
-	rm *.o
+	rm -f *.a
+	rm -f *.o

--- a/HuntTheWumpus/Makefile
+++ b/HuntTheWumpus/Makefile
@@ -28,7 +28,7 @@ $(1)/%.o: %.cpp
 endef
 
 HuntTheWumpus: $(OBJ) directories HuntTheWumpusLib
-	g++ -L../HuntTheWumpusLib $(OBJ) -o ../bin/HuntTheWumpus -lHuntTheWumpus
+	$(CC) -L../HuntTheWumpusLib $(OBJ) -o ../bin/HuntTheWumpus -lHuntTheWumpus
 
 HuntTheWumpusLib:
 	$(MAKE) -j -C ../HuntTheWumpusLib all

--- a/HuntTheWumpusLib/Denizen.cpp
+++ b/HuntTheWumpusLib/Denizen.cpp
@@ -3,6 +3,7 @@
 #include <bit>
 #include <functional>
 #include <iostream>
+#include <limits>
 
 namespace HuntTheWumpus
 {
@@ -63,7 +64,7 @@ namespace HuntTheWumpus
     uint32_t distribute(const uint32_t n)
     {
         constexpr uint32_t p = 0x55555555ul; // pattern of alternating 0 and 1
-        constexpr uint32_t c = 3423571495ul; // random uneven integer constant; 
+        constexpr uint32_t c = 3423571495ul; // random uneven integer constant;
         return static_cast<uint32_t>(c * xorshift(p * xorshift(n, 16), 16));
     }
 

--- a/UnitTestHuntTheWumpus/Makefile
+++ b/UnitTestHuntTheWumpus/Makefile
@@ -28,7 +28,7 @@ $(1)/%.o: %.cpp
 endef
 
 UnitTestHuntTheWumpus: $(OBJ) directories HuntTheWumpusLib CppUnitLite
-	g++ -L../HuntTheWumpusLib -L../CppUnitLite $(OBJ) -o ../bin/UnitTestHuntTheWumpus -lHuntTheWumpus -lCppUnitLite $(OPTFLAGS)
+	$(CC) -L../HuntTheWumpusLib -L../CppUnitLite $(OBJ) -o ../bin/UnitTestHuntTheWumpus -lHuntTheWumpus -lCppUnitLite $(OPTFLAGS)
 
 HuntTheWumpusLib:
 	$(MAKE) -j -C ../HuntTheWumpusLib all


### PR DESCRIPTION
- CppUnitLite: Fix build error on "make clean" if no output files.
- HuntTheWumpusLib: Add #include<limits> to Denizen.cpp for GCC.
- UnitTestHuntTheWumpus: Use CC everywhere in Makefile.
